### PR TITLE
fix formatting on clickable images on session format page

### DIFF
--- a/formats.md
+++ b/formats.md
@@ -3,11 +3,13 @@ layout: page
 title: OSR Session Formats
 ---
 
-OSR will have one of the following formats: 
+OSR will have one of the following formats:
 
-[<img align="left" src="../img/educational_geg.svg" height="250" alt="OSR-Ed">](#educational)
-[<img align="center" src="../img/panel_geg.svg" height="250" alt="Panel">](#panel)
-[<img align="right" src="../img/emergent_geg.svg" height="250" alt="Emergent">](#emergent)
+<div class="column">
+    <a href="#educational"><img src="../img/educational_geg.svg" height="250" style="width:32%" alt="OSR-Ed"></a>
+    <a href="#panel"><img src="../img/panel_geg.svg" height="250" style="width:32%" alt="Panel"></a>
+    <a href="#emergent"><img src="../img/emergent_geg.svg" height="250" style="width:32%" alt="Emergent"></a>
+</div>
 
 {::options parse_block_html="true" /}
 <p align="justify">
@@ -15,7 +17,7 @@ As for the main OHBM conference, this year's OSR will happen across in hybrid fo
 </p>
 {::options parse_block_html="false" /}
 
---- 
+---
 
 {::options parse_block_html="true" /}
 
@@ -29,7 +31,7 @@ As for the main OHBM conference, this year's OSR will happen across in hybrid fo
 
 <p align="justify">**How can I view Educational Sessions?**</p>
 <p align="justify"> Educational Sessions are pre-recorded and broadcast for everyone, anytime, and in any time zone! The educational sessions will forever live on Youtube and DouYu. You can also leave questions on the video posts and speakers will be encouraged to get back to you.</p>
-  
+
 <br/>
 <br/>
 
@@ -42,7 +44,7 @@ As for the main OHBM conference, this year's OSR will happen across in hybrid fo
 {% include youtubePlayer.html id="xSGlsht4eHw" %}
 <p align="justify">**What are Panel Sessions?**</p>
 <p align="justify"> Panel Sessions are discussions amongst selected speakers and OSR attendees about various relevant topics, spanning across all aspects of open science practices.
-In the 2022 OSR, we aim to address new and emerging topics in the discipline, along with big picture issues in open science. The OSR Panel Sessions are also a space to meet 
+In the 2022 OSR, we aim to address new and emerging topics in the discipline, along with big picture issues in open science. The OSR Panel Sessions are also a space to meet
 and interact with invited panelists about a multitude of topics. Since this year's OSR is hybrid, we aim to create in-person and virtual sessions, which will be 'live' and re-broadcasted
 to support everyone in making real connections with other attendees and panelists.</p>
 
@@ -60,18 +62,18 @@ Questions from the audience are encouraged (via chat feature if virtual) and wil
 <div id='emergent'></div>
 <br/>
 <br/>
- 
+
 {% include youtubePlayer.html id="hJ6i2jUQlnQ" %}
 <p align="justify">**What are Emergent Sessions?**</p>
 <p align="justify"> Emergent Sessions are spontaneous and interactive hot topic talks hosted by OSR attendees. Emergent sessions may last from 15 minutes to one hour. The duration will be set by the participant organizer, or it will run for as long as the conversation is flowing. Emergent Sessions can be framed as conversations held in an open format among peers. These sessions may be used to invite contributions to collaborative projects,hold an open forum to discuss a development in existing projects, hold a panel discussion, or basically anything you would like!</p>
 
-<p align="justify">**Emergent Sessions** are [bookable](/submit.md){:target="_blank"}.</p> 
+<p align="justify">**Emergent Sessions** are [bookable](/submit.md){:target="_blank"}.</p>
 
 <p align="justify">**How do I host an Emergent Session?**</p>
-<p align="justify"> Emergent Sessions are bookable during the meeting for times allocated for Emergent Sessions. 
-Emergent Sessions can be booked by any OHBM or OSR registered participant at any point in the meeting, while there is space in the schedule. 
+<p align="justify"> Emergent Sessions are bookable during the meeting for times allocated for Emergent Sessions.
+Emergent Sessions can be booked by any OHBM or OSR registered participant at any point in the meeting, while there is space in the schedule.
 Submitted Emergent requests will be briefly reviewed by the OSR team for appropriate content, and details communicated regarding how to book a slot in our schedule. We will be on hand to manage the hosting and broadcast of your session on your behalf, and help your participants join the conversation.</p>
- 
+
 <p align="justify">**How can I attend Emergent Sessions if I am a virtual attendee?**</p>
 <p align="justify"> All Emergent Sessions will be live streamed and recorded (unless we have specific reason to think this would inhibit discussion). The recorded sessions will be made available for viewing on Crowdcast straight after the event. Links to this “spontaneously” recorded material will be shared with registered participants.</p>
 


### PR DESCRIPTION
fixes #8 


Full view of the Formats page (no shrinking of the page)
<img width="1413" alt="Screen Shot 2022-04-06 at 8 10 09 PM" src="https://user-images.githubusercontent.com/52056183/162112876-b77e9c89-32c3-420c-8f4b-6fe542f41ffc.png">


View of the formats page when shrunk. Photos no longer wrap to a new row.
<img width="518" alt="Screen Shot 2022-04-06 at 8 10 24 PM" src="https://user-images.githubusercontent.com/52056183/162112922-091173a9-bac5-4c0e-b386-549a53c9c442.png">

