### PR TITLE
:lipstick: change style from cover to contain at .intro-header.big-img

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -438,10 +438,10 @@ footer .theme-by {
 }
 .intro-header.big-img {
   background: no-repeat center center;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  background-size: cover;
-  -o-background-size: cover;
+  -webkit-background-size: contain;
+  -moz-background-size: contain;
+  background-size: contain;
+  -o-background-size: contain;
   margin-top: 51px; /* The small navbar is 50px tall + 1px border */
   margin-bottom: 35px;
 }


### PR DESCRIPTION
The header image on the main page has been cropped a little from the CSS "cover" style.
![image](https://user-images.githubusercontent.com/34869980/162009340-d8b17f3f-251b-48c8-8fcf-6a710a343ca4.png)

just change the style to "contain" to show a full image.
![image](https://user-images.githubusercontent.com/34869980/162010065-efc2ed82-6933-476e-90f9-013c25abb146.png)
