### PR TITLE
Fix embedded YouTube video aspect ratios

### DIFF
--- a/_includes/youtubePlayer.html
+++ b/_includes/youtubePlayer.html
@@ -1,8 +1,8 @@
 <div class="youtube-container">
   <iframe
       src="https://www.youtube.com/embed/{{ include.id }}"
-      width="80%"
-      height="100%"
+      width="100%"
+      height="88%"
       frameborder="0"
       allowfullscreen>
   </iframe>


### PR DESCRIPTION
Update youtubePlayer.html include file width and height to fit aspect ratios of OSSIG videos embedded on formats page. See issue #15 