### PR TITLE
Add additional check on speaker.Panel to avoid null elements

### DIFF
--- a/panel.md
+++ b/panel.md
@@ -10,7 +10,7 @@ function getPanelSpeakersForPanelName(panelName) {
   // Filter all speakers to select only those that are in the given panel
   const speakers = {{ site.data.speakers | jsonify }};
   const panelSpeakers = speakers.filter(speaker => speaker.Panel !== undefined);
-  return panelSpeakers.filter(speaker => (speaker.Panel.toLowerCase().includes(panelName.toLowerCase())));
+  return panelSpeakers.filter(speaker => (speaker.Panel && speaker.Panel.toLowerCase().includes(panelName.toLowerCase())));
 }
 
 function getUrlForSpeaker(speaker) {


### PR DESCRIPTION
#21 is not properly working when deployed, but this is a bug I cannot reproduce locally. I'm trying to add this check on the value of `speaker.Panel` to make sure it is non-null. Hope this works!