### PR TITLE
Fix schedule buttons

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1327,12 +1327,19 @@ time.start-time, time.end-time {
   color: white;
 }
 
+/* The block contains iframes which are improperly loaded if we use display: none;*/
+/* Instead we just move the block far away left */
+/* As we use an absolute positioning, there is not a height computed anymore for the element */
+/* so we add below a div that has a large margin-top to leave space for the schedule */
 .schedule-block {
-  display: none;
+  position: absolute;
+  left: -5000px;
 }
 
 .schedule-block.active {
   display: block;
+  position: center;
+  left:0px;
 }
 
 .schedule-content {
@@ -1348,4 +1355,19 @@ time.start-time, time.end-time {
   text-align: center;
 }
 
+.schedule-leave-space-before-footer {
+  margin-top: 550px;
+}
+
+@media only screen and (max-width: 500px) {
+  .schedule-leave-space-before-footer {
+    margin-top:600px;
+  }
+}
+
+@media only screen and (max-width: 400px) {
+  .schedule-leave-space-before-footer {
+    margin-top:650px;
+  }
+}
 /* SCHEDULE END */

--- a/schedule.md
+++ b/schedule.md
@@ -139,8 +139,8 @@ GMT+1
                 <td>14:45 ➡ 15:45</td>
                 <td>
                     <div>Panel 3: Open Code - 6 Myths Debunked</div>
-                    <a href="https://add.eventable.com/events/629a28543ef85c3ac00e5e83/629a4a43a7c9374f60d948fd/" data-event="629a4a43a7c9374f60d948fd" class="eventable-link" target="_blank" data-key="629a28543ef85c3ac00e5e83" data-style="1">Add to Calendar</a>
                     <div><a href="https://www.crowdcast.io/e/panel-3-open-code-6" target="_blank">Click here to join this panel!</a></div>
+                    <a href="https://add.eventable.com/events/629a28543ef85c3ac00e5e83/629a4a43a7c9374f60d948fd/" data-event="629a4a43a7c9374f60d948fd" class="eventable-link" target="_blank" data-key="629a28543ef85c3ac00e5e83" data-style="1">Add to Calendar</a>
                 </td>
             </tr>
             <tr>

--- a/schedule.md
+++ b/schedule.md
@@ -3,6 +3,7 @@ layout: page
 title: Schedule
 ---
 
+
 <script>
 const ALL_DAYS = ["06-20", "06-21", "06-22", "06-23"];
 
@@ -138,8 +139,8 @@ GMT+1
                 <td>14:45 ➡ 15:45</td>
                 <td>
                     <div>Panel 3: Open Code - 6 Myths Debunked</div>
+                    <a href="https://add.eventable.com/events/629a28543ef85c3ac00e5e83/629a4a43a7c9374f60d948fd/" data-event="629a4a43a7c9374f60d948fd" class="eventable-link" target="_blank" data-key="629a28543ef85c3ac00e5e83" data-style="1">Add to Calendar</a>
                     <div><a href="https://www.crowdcast.io/e/panel-3-open-code-6" target="_blank">Click here to join this panel!</a></div>
-                    <a href="https://add.eventable.com/events/629a28543ef85c3ac00e5e83/629a4abd1fd9d50830ca3664/" class="eventable-link" target="_blank" data-key="629a28543ef85c3ac00e5e83" data-key="629a28543ef85c3ac00e5e83" data-style="1">Add to Calendar</a>
                 </td>
             </tr>
             <tr>
@@ -152,7 +153,6 @@ GMT+1
         </table>
     </div>
 </div>
-
 
 <div id="schedule-06-22" class="schedule-block">
     <h4>June 22, Wednesday</h4>
@@ -234,6 +234,9 @@ GMT+1
 
 </div>
 
+<div class="schedule-leave-space-before-footer">
+    <a href="https://calendar.google.com/calendar/u/0?cid=MjQydjZtZGFpcWQydWM0YzVlNDcxazA2Nm9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ" target="_blank">CLICK HERE TO ADD THE OSR SCHEDULE TO YOUR GOOGLE CALENDAR!</a>
+</div>
+
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src='https://plugins.eventable.com/eventable.js';fjs.parentNode.insertBefore(js,fjs);}}(document,'script', 'eventable-script');</script>
 
-[CLICK HERE TO ADD THE OSR SCHEDULE TO YOUR GOOGLE CALENDAR!](https://calendar.google.com/calendar/u/0?cid=MjQydjZtZGFpcWQydWM0YzVlNDcxazA2Nm9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)


### PR DESCRIPTION
Fixes #33 

The problem was that eventable loads iframes that do not properly load when you use display:none; property in the css. This is what we use to display only the selected day.

I've moved to a kind of hacky but working solution where we just display all the elements but far away from the screen, and only the current day appears in the right place. Here are some screenshots:

![image](https://user-images.githubusercontent.com/12402673/174085590-56e7cbdc-a549-4fe2-8c1d-144b5772c2cf.png)
![image](https://user-images.githubusercontent.com/12402673/174085753-d3427598-7f66-4c69-a6b8-649ddcb97988.png)
![image](https://user-images.githubusercontent.com/12402673/174085788-a2c34033-b3bb-4477-be96-bd5245f127fa.png)
